### PR TITLE
Added clientOrderId parameter to EditOrderAsync() (spot)

### DIFF
--- a/GateIo.Net.UnitTests/RestRequestTests.cs
+++ b/GateIo.Net.UnitTests/RestRequestTests.cs
@@ -118,7 +118,7 @@ namespace Gate.io.Net.UnitTests
             await tester.ValidateAsync(client => client.SpotApi.Trading.GetOrderAsync("ETH_USDT", 123), "GetOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelAllOrdersAsync("ETH_USDT"), "CancelAllOders", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrdersAsync(new[] { new GateIoBatchCancelRequest { Id = "123", Symbol = "ETH_USDT" } }), "CancelOrders");
-            await tester.ValidateAsync(client => client.SpotApi.Trading.EditOrderAsync("ETH_USDT", 123, 123), "EditOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
+            await tester.ValidateAsync(client => client.SpotApi.Trading.EditOrderAsync("ETH_USDT", 123, price: 123), "EditOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrderAsync("ETH_USDT", 123), "CancelOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.GetUserTradesAsync(), "GetUserTrades", ignoreProperties: new List<string> { "create_time" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrdersAfterAsync(TimeSpan.Zero), "CancelOrdersAfter");

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
@@ -223,13 +223,16 @@ namespace GateIo.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<GateIoOrder>> EditOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,
             SpotAccountType? accountType = null,
             CancellationToken ct = default)
         {
+            var id = orderId?.ToString() ?? clientOrderId;
+
             var queryParameters = new ParameterCollection();
             queryParameters.Add("currency_pair", symbol);
 
@@ -238,7 +241,7 @@ namespace GateIo.Net.Clients.SpotApi
             bodyParameters.AddOptionalString("amount", quantity);
             bodyParameters.AddOptional("amend_text", amendText);
             bodyParameters.AddOptionalEnum("account", accountType);
-            var request = _definitions.GetOrCreate(new HttpMethod("Patch"), "/api/v4/spot/orders/" + orderId, GateIoExchange.RateLimiter.RestSpotOrderPlacement, 1, true);
+            var request = _definitions.GetOrCreate(new HttpMethod("Patch"), "/api/v4/spot/orders/" + id, GateIoExchange.RateLimiter.RestSpotOrderPlacement, 1, true);
             return await _baseClient.SendAsync<GateIoOrder>(request, queryParameters, bodyParameters, ct).ConfigureAwait(false);
         }
 

--- a/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
@@ -275,7 +275,8 @@ namespace GateIo.Net.Clients.SpotApi
 
         /// <inheritdoc />
         public async Task<CallResult<GateIoOrder>> EditOrderAsync(string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,
@@ -290,7 +291,7 @@ namespace GateIo.Net.Clients.SpotApi
                 Quantity = quantity,
                 Price = price,
                 AmendText = amendText,
-                OrderId = orderId.ToString()
+                OrderId = orderId?.ToString() ?? clientOrderId!
             }, true);
 
             return await QueryAsync(BaseAddress.AppendPath("ws/v4/") + "/", query, ct).ConfigureAwait(false);

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
@@ -134,7 +134,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/#amend-an-order" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
+        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>
@@ -143,7 +144,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <returns></returns>
         Task<WebCallResult<GateIoOrder>> EditOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
@@ -134,8 +134,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/#amend-an-order" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
-        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
@@ -254,7 +254,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/ws/en/#order-amend" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
+        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>
@@ -262,7 +263,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<CallResult<GateIoOrder>> EditOrderAsync(string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
@@ -254,8 +254,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/ws/en/#order-amend" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
-        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>


### PR DESCRIPTION
REST and ws APIs allow order amending by client order id. This PR adds this feature for spot endpoints.