### PR TITLE
Add clientOrderId parameter to `CancelOrderAsync()` (spot market)

### DIFF
--- a/GateIo.Net.UnitTests/RestRequestTests.cs
+++ b/GateIo.Net.UnitTests/RestRequestTests.cs
@@ -118,7 +118,7 @@ namespace Gate.io.Net.UnitTests
             await tester.ValidateAsync(client => client.SpotApi.Trading.GetOrderAsync("ETH_USDT", 123), "GetOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelAllOrdersAsync("ETH_USDT"), "CancelAllOders", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrdersAsync(new[] { new GateIoBatchCancelRequest { Id = "123", Symbol = "ETH_USDT" } }), "CancelOrders");
-            await tester.ValidateAsync(client => client.SpotApi.Trading.EditOrderAsync("ETH_USDT", 123, 123), "EditOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
+            await tester.ValidateAsync(client => client.SpotApi.Trading.EditOrderAsync("ETH_USDT", 123, price: 123), "EditOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrderAsync("ETH_USDT", 123), "CancelOrder", ignoreProperties: new List<string> { "create_time", "update_time", "fill_price" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.GetUserTradesAsync(), "GetUserTrades", ignoreProperties: new List<string> { "create_time" });
             await tester.ValidateAsync(client => client.SpotApi.Trading.CancelOrdersAfterAsync(TimeSpan.Zero), "CancelOrdersAfter");

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApi.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApi.cs
@@ -298,13 +298,15 @@ namespace GateIo.Net.Clients.SpotApi
 
         async Task<WebCallResult<OrderId>> IBaseRestClient.CancelOrderAsync(string orderId, string? symbol, CancellationToken ct)
         {
-            if (!long.TryParse(orderId, out var id))
+            var clientOrderId = orderId.StartsWith("t-") ? orderId : null;
+
+            if (!long.TryParse(orderId, out var id) && clientOrderId is null)
                 throw new ArgumentException("Order id invalid", nameof(orderId));
 
             if (string.IsNullOrWhiteSpace(symbol))
                 throw new ArgumentException(nameof(symbol) + " required for Gate.io " + nameof(ISpotClient.CancelOrderAsync), nameof(symbol));
 
-            var order = await Trading.CancelOrderAsync(symbol!, id, ct: ct).ConfigureAwait(false);
+            var order = await Trading.CancelOrderAsync(symbol!, orderId: id == 0 ? null : id, clientOrderId: clientOrderId, ct: ct).ConfigureAwait(false);
             if (!order)
                 return order.As<OrderId>(null);
 

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiShared.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiShared.cs
@@ -431,10 +431,12 @@ namespace GateIo.Net.Clients.SpotApi
             if (validationError != null)
                 return new ExchangeWebResult<SharedId>(Exchange, validationError);
 
-            if (!long.TryParse(request.OrderId, out var orderId))
+            var clientOrderId = request.OrderId.StartsWith("t-") ? request.OrderId : null;
+            
+            if (!long.TryParse(request.OrderId, out var orderId) && clientOrderId is null)
                 return new ExchangeWebResult<SharedId>(Exchange, new ArgumentError("Invalid order id"));
 
-            var order = await Trading.CancelOrderAsync(request.Symbol.GetSymbol(FormatSymbol), orderId).ConfigureAwait(false);
+            var order = await Trading.CancelOrderAsync(request.Symbol.GetSymbol(FormatSymbol), orderId == 0 ? null : orderId, clientOrderId).ConfigureAwait(false);
             if (!order)
                 return order.AsExchangeResult<SharedId>(Exchange, null, default);
 

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiShared.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiShared.cs
@@ -431,10 +431,10 @@ namespace GateIo.Net.Clients.SpotApi
             if (validationError != null)
                 return new ExchangeWebResult<SharedId>(Exchange, validationError);
 
-            var clientOrderId = request.OrderId.StartsWith("t-") ? request.OrderId : null;
-            
-            if (!long.TryParse(request.OrderId, out var orderId) && clientOrderId is null)
-                return new ExchangeWebResult<SharedId>(Exchange, new ArgumentError("Invalid order id"));
+            string? clientOrderId = null;
+
+            if (!long.TryParse(request.OrderId, out var orderId))
+                clientOrderId = $"t-{request.OrderId}";
 
             var order = await Trading.CancelOrderAsync(request.Symbol.GetSymbol(FormatSymbol), orderId == 0 ? null : orderId, clientOrderId).ConfigureAwait(false);
             if (!order)

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
@@ -267,14 +267,17 @@ namespace GateIo.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<GateIoOrder>> CancelOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             SpotAccountType? accountType = null,
             CancellationToken ct = default)
         {
+            var id = orderId?.ToString() ?? clientOrderId ?? throw new ArgumentException($"Either {nameof(orderId)} or {nameof(clientOrderId)} must be provided"); ;
+
             var parameters = new ParameterCollection();
             parameters.Add("currency_pair", symbol);
             parameters.AddOptionalEnum("account", accountType);
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/api/v4/spot/orders/" + orderId, GateIoExchange.RateLimiter.RestSpotOrderCancelation, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/api/v4/spot/orders/" + id, GateIoExchange.RateLimiter.RestSpotOrderCancelation, 1, true);
             var result = await _baseClient.SendAsync<GateIoOrder>(request, parameters, ct).ConfigureAwait(false);
             if (result)
                 _baseClient.InvokeOrderCanceled(new CryptoExchange.Net.CommonObjects.OrderId

--- a/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoRestClientSpotApiTrading.cs
@@ -223,13 +223,16 @@ namespace GateIo.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<GateIoOrder>> EditOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,
             SpotAccountType? accountType = null,
             CancellationToken ct = default)
         {
+            var id = orderId?.ToString() ?? clientOrderId;
+
             var queryParameters = new ParameterCollection();
             queryParameters.Add("currency_pair", symbol);
 
@@ -238,7 +241,7 @@ namespace GateIo.Net.Clients.SpotApi
             bodyParameters.AddOptionalString("amount", quantity);
             bodyParameters.AddOptional("amend_text", amendText);
             bodyParameters.AddOptionalEnum("account", accountType);
-            var request = _definitions.GetOrCreate(new HttpMethod("Patch"), "/api/v4/spot/orders/" + orderId, GateIoExchange.RateLimiter.RestSpotOrderPlacement, 1, true);
+            var request = _definitions.GetOrCreate(new HttpMethod("Patch"), "/api/v4/spot/orders/" + id, GateIoExchange.RateLimiter.RestSpotOrderPlacement, 1, true);
             return await _baseClient.SendAsync<GateIoOrder>(request, queryParameters, bodyParameters, ct).ConfigureAwait(false);
         }
 

--- a/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
@@ -275,7 +275,8 @@ namespace GateIo.Net.Clients.SpotApi
 
         /// <inheritdoc />
         public async Task<CallResult<GateIoOrder>> EditOrderAsync(string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,
@@ -290,7 +291,7 @@ namespace GateIo.Net.Clients.SpotApi
                 Quantity = quantity,
                 Price = price,
                 AmendText = amendText,
-                OrderId = orderId.ToString()
+                OrderId = orderId?.ToString() ?? clientOrderId!
             }, true);
 
             return await QueryAsync(BaseAddress.AppendPath("ws/v4/") + "/", query, ct).ConfigureAwait(false);

--- a/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Clients/SpotApi/GateIoSocketClientSpotApi.cs
@@ -298,12 +298,16 @@ namespace GateIo.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<GateIoOrder>> CancelOrderAsync(string symbol, long orderId, SpotAccountType? accountType = null, CancellationToken ct = default)
+        public async Task<CallResult<GateIoOrder>> CancelOrderAsync(string symbol,
+            long? orderId = null,
+            string? clientOrderId = null,
+            SpotAccountType? accountType = null,
+            CancellationToken ct = default)
         {
             var id = ExchangeHelpers.NextId();
             var query = new GateIoRequestQuery<GateIoSpotGetOrderRequest, GateIoOrder>(id, "spot.order_cancel", "api", new GateIoSpotGetOrderRequest
             {
-                OrderId = orderId.ToString(),
+                OrderId = orderId?.ToString() ?? clientOrderId ?? throw new ArgumentException($"Either {nameof(orderId)} or {nameof(clientOrderId)} must be provided"),
                 Symbol = symbol,
                 AccountType = accountType
             }, true);

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
@@ -134,7 +134,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/#amend-an-order" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
+        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>
@@ -143,7 +144,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <returns></returns>
         Task<WebCallResult<GateIoOrder>> EditOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
@@ -157,13 +157,15 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/#cancel-a-single-order" /></para>
         /// </summary>
         /// <param name="symbol">Symbol of the order, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="accountType">Account type</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<GateIoOrder>> CancelOrderAsync(
             string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             SpotAccountType? accountType = null,
             CancellationToken ct = default);
 

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoRestClientSpotApiTrading.cs
@@ -134,8 +134,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/#amend-an-order" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
-        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
@@ -254,7 +254,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/ws/en/#order-amend" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
+        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>
@@ -262,7 +263,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<CallResult<GateIoOrder>> EditOrderAsync(string symbol,
-            long orderId,
+            long? orderId = null,
+            string? clientOrderId = null,
             decimal? price = null,
             decimal? quantity = null,
             string? amendText = null,

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
@@ -223,11 +223,16 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/ws/en/#order-cancel" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="accountType">Account type</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<CallResult<GateIoOrder>> CancelOrderAsync(string symbol, long orderId, SpotAccountType? accountType = null, CancellationToken ct = default);
+        Task<CallResult<GateIoOrder>> CancelOrderAsync(string symbol,
+            long? orderId,
+            string? clientOrderId = null,
+            SpotAccountType? accountType = null,
+            CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders

--- a/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
+++ b/GateIo.Net/Interfaces/Clients/SpotApi/IGateIoSocketClientSpotApi.cs
@@ -254,8 +254,8 @@ namespace GateIo.Net.Interfaces.Clients.SpotApi
         /// <para><a href="https://www.gate.io/docs/developers/apiv4/ws/en/#order-amend" /></para>
         /// </summary>
         /// <param name="symbol">Symbol, for example `ETH_USDT`</param>
-        /// <param name="orderId">Order id, either orderId or clientOrderId required</param>
-        /// <param name="clientOrderId">user custom ID(i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
+        /// <param name="orderId">Order id, either `orderId` or `clientOrderId` required</param>
+        /// <param name="clientOrderId">user custom ID (i.e., t-123c456f), either `orderId` or `clientOrderId` required</param>
         /// <param name="price">New price</param>
         /// <param name="quantity">New quantity</param>
         /// <param name="amendText">Custom info during amending order</param>


### PR DESCRIPTION
Both REST and WebSocket APIs allow canceling order by clientOrderId. Added this feature to the library.

doc ref:
https://www.gate.io/docs/developers/apiv4/#cancel-a-single-order
https://www.gate.io/docs/developers/apiv4/ws/en/#order-cancel

resolve #9