### PR TITLE
cross_leverage_limit may decimals

### DIFF
--- a/GateIo.Net/Objects/Models/GateIoPosition.cs
+++ b/GateIo.Net/Objects/Models/GateIoPosition.cs
@@ -148,7 +148,7 @@ namespace GateIo.Net.Objects.Models
         /// Cross margin leverage
         /// </summary>
         [JsonPropertyName("cross_leverage_limit")]
-        public int? CrossLeverageLimit { get; set; }
+        public decimal? CrossLeverageLimit { get; set; }
         /// <summary>
         /// Update id
         /// </summary>

--- a/GateIo.Net/Objects/Models/GateIoPositionUpdate.cs
+++ b/GateIo.Net/Objects/Models/GateIoPositionUpdate.cs
@@ -97,6 +97,6 @@ namespace GateIo.Net.Objects.Models
         /// Cross margin leverage
         /// </summary>
         [JsonPropertyName("cross_leverage_limit")]
-        public int? CrossLeverageLimit { get; set; }
+        public decimal? CrossLeverageLimit { get; set; }
     }
 }


### PR DESCRIPTION
GateIoRestClient.PerpetualFuturesApi.Trading.GetPositionsAsync("usdt") throw an exception:
```text
Unknown exception: The input string '7.5' was not in a correct format.
```

Original data:

[
...,
{
	"value": "0",
	"leverage": "0",
	"mode": "dual_short",
	"realised_point": "0",
	"contract": "ALPACA_USDT",
	"entry_price": "0",
	"mark_price": "0.24727",
	"history_point": "0",
	"realised_pnl": "0",
	"close_order": null,
	"size": 0,
	**"cross_leverage_limit": "7.5"**,
	"pending_orders": 0,
	"adl_ranking": 6,
	"maintenance_rate": "0.11",
	"unrealised_pnl": "0",
	"pnl_pnl": "0",
	"pnl_fee": "0",
	"pnl_fund": "0",
	"user": 21812194,
	"leverage_max": "7.5",
	"history_pnl": "-915.42035964423",
	"risk_limit": "10000",
	"margin": "0",
	"last_close_pnl": "4.45711552",
	"liq_price": "0",
	"update_time": 1746687210,
	"update_id": 1472,
	"initial_margin": "0",
	"maintenance_margin": "0",
	"open_time": 0,
	"trade_max_size": "0"
},
...
]